### PR TITLE
Add-Edit-Delete Position Categories Under Human Resources Setup

### DIFF
--- a/src/test/java/FeatureFiles/_IP1FETWC-1-Add-Edit-Delete_Position_Categories.feature
+++ b/src/test/java/FeatureFiles/_IP1FETWC-1-Add-Edit-Delete_Position_Categories.feature
@@ -20,7 +20,6 @@ As an Admin User I should be able to Add-Edit-Delete Position Categories Under H
     When Add a new position
     Then Success message should be displayed
 
-
   Scenario: Edit a new position
     When Edit a new position
     Then Success message should be displayed

--- a/src/test/java/Pages/DialogContent.java
+++ b/src/test/java/Pages/DialogContent.java
@@ -92,4 +92,11 @@ public class DialogContent extends MyMethods {
 
     @FindBy(css = "iframe[class=\"tox-edit-area__iframe\"]")
     public WebElement iFrame;
+
+    @FindBy(xpath = "(//input[@data-placeholder='Short Name'])[2]")
+    public WebElement addShortName;
+
+    @FindBy(xpath = "//button[@color='accent']")
+    public WebElement editButton;
+
 }

--- a/src/test/java/Pages/LeftNavBar.java
+++ b/src/test/java/Pages/LeftNavBar.java
@@ -39,10 +39,10 @@ public class LeftNavBar extends MyMethods {
     @FindBy(xpath = "//span[.='Human Resources']")
     public WebElement HumanResources;
 
-    @FindBy(xpath = "(//span[text()='Setup'])[2]")
-    public WebElement HumanResourcesSetUp;
+    @FindBy(xpath = "(//span[text()='Setup'])[3]")
+    public WebElement SetUpHumanResources;
 
-    @FindBy(css = "div[class=\"children ng-tns-c3380182179-17 ng-trigger ng-trigger-slideInOut ng-star-inserted\"] span")
+    @FindBy(xpath = "//span[.='Positions']")
     public WebElement Positions;
 
 }

--- a/src/test/java/StepDefinitions/Hooks.java
+++ b/src/test/java/StepDefinitions/Hooks.java
@@ -1,0 +1,47 @@
+package StepDefinitions;
+
+
+import Utilities.ExcelUtilities;
+import Utilities.ParameterDriver;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class Hooks {
+    LocalDateTime startTime;
+    LocalDateTime endTime;
+
+    @Before // Runs before each scenario in the feature files
+    public void beforeScenario() {
+        startTime = LocalDateTime.now();
+        System.out.println("Before Scenario runs");
+    }
+
+    @After // Runs after each scenario in the feature files
+    public void afterScenario(Scenario scenario) {
+        endTime = LocalDateTime.now();
+        Duration duration = Duration.between(startTime,endTime);
+        if (scenario.isFailed()) { // take screen shot when the scenario fails
+            final byte[] byteImage = ((TakesScreenshot) ParameterDriver.getDriver()).getScreenshotAs(OutputType.BYTES);
+            scenario.attach(byteImage, "image/png", scenario.getName());
+        }
+        ExcelUtilities.writeInExcel("src/test/java/ApachePOI/Resources/CampusScenarioResults.xlsx", scenario,startTime, endTime,duration);
+        ParameterDriver.quitDriver();
+    }
+
+//    @BeforeStep // Runs before each step in a scenario in the feature files
+//    public void beforeStep(){
+//        System.out.println("Before Step runs");
+//    }
+//
+//    @AfterStep // Runs after each step in a scenario in the feature files
+//    public void afterStep(){
+//        System.out.println("After Step runs");
+//    }
+
+}

--- a/src/test/java/StepDefinitions/_IP1FETWC_1_Add_Edit_Delete_Position_Categories.java
+++ b/src/test/java/StepDefinitions/_IP1FETWC_1_Add_Edit_Delete_Position_Categories.java
@@ -3,20 +3,29 @@ package StepDefinitions;
 import Pages.DialogContent;
 import Pages.LeftNavBar;
 import Utilities.BaseDriver;
+import Utilities.MyMethods;
 import Utilities.ParameterDriver;
+import io.cucumber.core.internal.com.fasterxml.jackson.databind.ser.Serializers;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.apache.poi.ss.formula.ThreeDEval;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class _IP1FETWC_1_Add_Edit_Delete_Position_Categories {
+public class _IP1FETWC_1_Add_Edit_Delete_Position_Categories extends MyMethods {
 
     DialogContent dc = new DialogContent();
     LeftNavBar lb = new LeftNavBar();
@@ -28,8 +37,8 @@ public class _IP1FETWC_1_Add_Edit_Delete_Position_Categories {
 
     @Given("Enter username and password")
     public void enter_username_and_password() {
-        dc.sendKeysMethod(dc.username,"turkeyts");
-        dc.sendKeysMethod(dc.password,"TechnoStudy123");
+        dc.sendKeysMethod(dc.username, "turkeyts");
+        dc.sendKeysMethod(dc.password, "TechnoStudy123");
     }
 
     @When("Click on Login Button")
@@ -39,24 +48,28 @@ public class _IP1FETWC_1_Add_Edit_Delete_Position_Categories {
 
     @And("Navigate to Human Resources page")
     public void navigateToHumanResourcesPage() {
+        waitUntilVisible(lb.HumanResources);
         lb.HumanResources.click();
     }
 
     @And("Click on Setup")
     public void clickOnSetup() {
-        lb.setUpButton.click();
+        waitUntilVisible(lb.SetUpHumanResources);
+        lb.SetUpHumanResources.click();
     }
 
     @And("Click on Positions")
     public void clickOnPositions() {
+        waitUntilVisible(lb.Positions);
         lb.Positions.click();
     }
 
     @When("Add a new position")
     public void addANewPosition() {
-        dc.addButton.click();
-        dc.searchNameInput.sendKeys("Alina");
-        dc.searchShortNameInput.sendKeys("Ali");
+        clickMethod(dc.addButton);
+        sendKeysMethod(dc.formNameInput, "alina");
+        sendKeysMethod(dc.addShortName, "a");
+        clickMethod(dc.saveButton);
     }
 
     @Then("Success message should be displayed")
@@ -65,10 +78,24 @@ public class _IP1FETWC_1_Add_Edit_Delete_Position_Categories {
     }
 
     @When("Edit a new position")
-    public void editANewPosition() {
+    public void editANewPosition() throws InterruptedException {
+        sendKeysMethod(dc.searchNameInput, "alina");
+        sendKeysMethod(dc.searchShortNameInput, "a");
+        clickMethod(dc.searchButton);
+        Thread.sleep(2000);
+        clickMethod(dc.editButton);
+        Thread.sleep(2000);
+        sendKeysMethod(dc.formNameInput, "Bella");
+        sendKeysMethod(dc.addShortName, "b");
+        clickMethod(dc.saveButton);
     }
 
     @When("Delete a new position")
     public void deleteANewPosition() {
+        sendKeysMethod(dc.searchNameInput, "Bella");
+        sendKeysMethod(dc.searchShortNameInput, "b");
+        clickMethod(dc.deleteButton);
+        clickMethod(dc.deleteConfirmButton);
+        successMessageShouldBeDisplayed();
     }
 }

--- a/src/test/java/Utilities/ExcelUtilities.java
+++ b/src/test/java/Utilities/ExcelUtilities.java
@@ -1,0 +1,110 @@
+package Utilities;
+
+
+import io.cucumber.java.Scenario;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+public class ExcelUtilities {
+    public static ArrayList<ArrayList<String>> getDataFromExcel(String path, String sheetName, int columnCount) {
+
+        FileInputStream fileInputStream;
+        Workbook workbook;
+        try {
+            fileInputStream = new FileInputStream(path);
+            workbook = WorkbookFactory.create(fileInputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Sheet sheet = workbook.getSheet(sheetName);
+
+        ArrayList<ArrayList<String>> returnList = new ArrayList<>(); // The sheet represents a 2D ArrayList
+
+        for (int i = 0; i < sheet.getPhysicalNumberOfRows(); i++) {
+            ArrayList<String> innerList = new ArrayList<>(); // Each row in the sheet represents inner lists
+            for (int j = 0; j < columnCount; j++) {
+                Cell cell = sheet.getRow(i).getCell(j); // Each cell represents elements of inner lists
+                innerList.add(cell.toString());
+            }
+            returnList.add(innerList);
+        }
+
+        return returnList;
+    }
+
+    public static void writeInExcel(String path, Scenario scenario, LocalDateTime startTime, LocalDateTime endTime, Duration duration) {
+        File file = new File(path);
+        if (!file.exists()) {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet sheet = workbook.createSheet("Campus Test Scenario Results");
+            Row row = sheet.createRow(0);
+            Cell cell = row.createCell(0);
+            cell.setCellValue(scenario.getId());
+            cell = row.createCell(1);
+            cell.setCellValue(scenario.getName());
+            cell = row.createCell(2);
+            cell.setCellValue(scenario.getStatus().toString());
+            cell = row.createCell(3);
+            cell.setCellValue(startTime);
+            cell = row.createCell(4);
+            cell.setCellValue(endTime);
+            cell = row.createCell(5);
+            cell.setCellValue(duration.toString());
+            try {
+                FileOutputStream fileOutputStream = new FileOutputStream(path);
+                workbook.write(fileOutputStream);
+                workbook.close();
+                fileOutputStream.close();
+            } catch (IOException e) {
+                System.out.println(e.getMessage());
+            }
+
+
+        } else {
+            FileInputStream fileInputStream;
+            Workbook workbook=null;
+            Sheet sheet = null;
+            try {
+                fileInputStream = new FileInputStream(path);
+                workbook = WorkbookFactory.create(fileInputStream);
+                sheet = workbook.getSheet("Campus Test Scenario Results");
+            } catch (IOException e) {
+                System.out.println(e.getMessage());
+            }
+
+            int rowCount = sheet.getPhysicalNumberOfRows();
+            Row row = sheet.createRow(rowCount);
+            Cell cell = row.createCell(0);
+            cell.setCellValue(scenario.getId());
+            cell = row.createCell(1);
+            cell.setCellValue(scenario.getName());
+            cell = row.createCell(2);
+            cell.setCellValue(scenario.getStatus().toString());
+            cell = row.createCell(3);
+            cell.setCellValue(startTime);
+            cell = row.createCell(4);
+            cell.setCellValue(endTime);
+            cell = row.createCell(5);
+            cell.setCellValue(duration.toString());
+
+            try {
+                FileOutputStream fileOutputStream = new FileOutputStream(path);
+                workbook.write(fileOutputStream);
+                workbook.close();
+                fileOutputStream.close();
+            } catch (IOException e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
As an Admin User

I should be able to Add-Edit-Delete Position Categories 

Under Human Resources Setup

Admin User should be able to Add Position Categories, Edit Position Categories and Delete Position Categories for setting up human resources details for management of schools.

Position Categories tab should be under Human Resources > Setup tab. And we should have search function for this page.